### PR TITLE
adds test for unexpected EOF errors

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -19,7 +19,7 @@ const (
 	//
 	//     https://play.golang.org/p/L6f4ItJLufv
 	//
-	guestEOFPattern = `Get https://api\..*/api/v1/nodes: EOF`
+	guestEOFPattern = `Get https://api\..*/api/v1/nodes: (unexpected )?EOF`
 
 	// guestTransientInvalidCertificatePattern regular expression defines the kind
 	// of transient errors related to certificates returned while the guest API is

--- a/api/error_test.go
+++ b/api/error_test.go
@@ -12,32 +12,37 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 		expectedMatch bool
 	}{
 		{
-			description:   "dns not ready",
+			description:   "case 1: dns not ready",
 			errorMessage:  "dial tcp: lookup api.5xchu.aws.gigantic.io on 10.96.0.10:53: no such host",
 			expectedMatch: true,
 		},
 		{
-			description:   "dns not ready incorrect port",
+			description:   "case 2: dns not ready incorrect port",
 			errorMessage:  "dial tcp: lookup api.5xchu.aws.gigantic.io on 10.96.0.10:443: no such host",
 			expectedMatch: false,
 		},
 		{
-			description:   "ingress not ready get request",
+			description:   "case 3: ingress not ready get request",
 			errorMessage:  "Get https://api.5xchu.aws.gigantic.io: x509: certificate is valid for ingress.local, not api.5xchu.aws.gigantic.io:",
 			expectedMatch: true,
 		},
 		{
-			description:   "API not ready get EOF request",
+			description:   "case 4: API not ready get EOF request",
 			errorMessage:  "Get https://api.5xchu.aws.gigantic.io/api/v1/nodes: EOF",
 			expectedMatch: true,
 		},
 		{
-			description:   "ingress not ready post request",
+			description:   "case 5: temporary issues with the master node serving the guest cluster API",
+			errorMessage:  "Get https://api.8dnxs.g8s.gorgoth.gridscale.kvm.gigantic.io/api/v1/nodes: unexpected EOF",
+			expectedMatch: true,
+		},
+		{
+			description:   "case 6: ingress not ready post request",
 			errorMessage:  "Post https://api.5xchu.aws.gigantic.io: x509: certificate is valid for ingress.local, not api.5xchu.aws.gigantic.io:",
 			expectedMatch: true,
 		},
 		{
-			description:   "ingress not ready post different domain",
+			description:   "case 7: ingress not ready post different domain",
 			errorMessage:  "Post https://api.5xchu.aws.gigantic.io: x509: certificate is valid for localhost, not api.5xchu.aws.gigantic.io:",
 			expectedMatch: false,
 		},


### PR DESCRIPTION
This PR adds support for situations I saw when testing the `kvm-operator` and its new support for managing nodes in the guest cluster's API. During cluster creation there seem to occur various of EOF errors which are partially "unexpected". Not sure where the difference is but we should manage them here. 