### PR TITLE
Add error case for timeouts getting k8s resources

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -14,12 +14,19 @@ const (
 	//
 	dnsNotReadyPattern = "dial tcp: lookup .* on .*:53: no such host"
 
-	// eofPattern is a regular expression representing EOF errors for the
+	// nodeEOFPattern is a regular expression representing EOF errors for the
 	// guest API domain. Also see the following match example.
 	//
 	//     https://play.golang.org/p/L6f4ItJLufv
 	//
-	eofPattern = `Get https://api\..*/api/v1/nodes.* (unexpected )?EOF`
+	nodeEOFPattern = `Get https://api\..*/api/v1/nodes.* (unexpected )?EOF`
+
+	// resourceEOFPattern is a regular expression representing EOF errors for the
+	// guest API domain. Also see the following match example.
+	//
+	//     https://play.golang.org/p/2x2BXd5iHuP
+	//
+	resourceEOFPattern = `[Get|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`
 
 	// transientInvalidCertificatePattern regular expression defines the kind
 	// of transient errors related to certificates returned while the guest API is
@@ -32,7 +39,8 @@ const (
 
 var (
 	dnsNotReadyRegexp                 = regexp.MustCompile(dnsNotReadyPattern)
-	eofRegexp                         = regexp.MustCompile(eofPattern)
+	nodeEOFRegexp                     = regexp.MustCompile(nodeEOFPattern)
+	resourceEOFRegexp                 = regexp.MustCompile(resourceEOFPattern)
 	transientInvalidCertificateRegexp = regexp.MustCompile(transientInvalidCertificatePattern)
 )
 
@@ -50,7 +58,8 @@ func IsAPINotAvailable(err error) bool {
 
 	regexps := []*regexp.Regexp{
 		dnsNotReadyRegexp,
-		eofRegexp,
+		nodeEOFRegexp,
+		resourceEOFRegexp,
 		transientInvalidCertificateRegexp,
 	}
 	for _, re := range regexps {

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -51,6 +51,16 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			errorMessage:  "Post https://api.5xchu.aws.gigantic.io: x509: certificate is valid for localhost, not api.5xchu.aws.gigantic.io:",
 			expectedMatch: false,
 		},
+		{
+			description:   "case 9: timeout getting namespace",
+			errorMessage:  "Get https://api.3jwh2.k8s.aws.gigantic.io/api/v1/namespaces/giantswarm?timeout=30s: EOF",
+			expectedMatch: true,
+		},
+		{
+			description:   "case 10: timeout getting service account",
+			errorMessage:  "Post https://api.3jwh2.k8s.aws.gigantic.io/api/v1/namespaces/giantswarm/serviceaccounts?timeout=30s: EOF",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We are getting a lot of false positives for the cluster-operator errors alert.

Today when testing cluster creation in viking I saw timeouts getting the giantswarm namespace and service accounts. Cluster creation succeeds eventually so we should just cancel the reconciliation.
