### PR TITLE
adds error handling for TLS handshake errors

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -28,9 +28,18 @@ const (
 	//
 	resourceEOFPattern = `[Get|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`
 
-	// transientInvalidCertificatePattern regular expression defines the kind
-	// of transient errors related to certificates returned while the guest API is
-	// not fully up. Also see the following match example.
+	// tlsHandshakeTimeoutPattern is a regular expression representing TLS
+	// handshake timeout errors related to establishing connections to guest
+	// clusters while the guest API is not fully up. Also see the following match
+	// example.
+	//
+	//     https://play.golang.org/p/KuH2V0IXo-J
+	//
+	tlsHandshakeTimeoutPattern = `Get https://api\..*/api/v1/nodes.* net/http: TLS handshake timeout`
+
+	// transientInvalidCertificatePattern is a regular expression representing the
+	// kind of transient errors related to certificates returned while the guest
+	// API is not fully up. Also see the following match example.
 	//
 	//     https://play.golang.org/p/iiYvBhPOg4f
 	//
@@ -41,6 +50,7 @@ var (
 	dnsNotReadyRegexp                 = regexp.MustCompile(dnsNotReadyPattern)
 	nodeEOFRegexp                     = regexp.MustCompile(nodeEOFPattern)
 	resourceEOFRegexp                 = regexp.MustCompile(resourceEOFPattern)
+	tlsHandshakeTimeoutRegexp         = regexp.MustCompile(tlsHandshakeTimeoutPattern)
 	transientInvalidCertificateRegexp = regexp.MustCompile(transientInvalidCertificatePattern)
 )
 
@@ -60,6 +70,7 @@ func IsAPINotAvailable(err error) bool {
 		dnsNotReadyRegexp,
 		nodeEOFRegexp,
 		resourceEOFRegexp,
+		tlsHandshakeTimeoutRegexp,
 		transientInvalidCertificateRegexp,
 	}
 	for _, re := range regexps {

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -61,6 +61,11 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			errorMessage:  "Post https://api.3jwh2.k8s.aws.gigantic.io/api/v1/namespaces/giantswarm/serviceaccounts?timeout=30s: EOF",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 11: timeout establishing TLS handshake",
+			errorMessage:  "Get https://api.08vka.k8s.gorgoth.gridscale.kvm.gigantic.io/api/v1/nodes?timeout=30s: net/http: TLS handshake timeout",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I caught a case on KVM where a cluster got created and the `node` resource tried to reach the guest API but failed with this error. 

```
Get https://api.08vka.k8s.gorgoth.gridscale.kvm.gigantic.io/api/v1/nodes?timeout=30s: net/http: TLS handshake timeout
```

```
{"caller":"github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:74","event":"update","level":"warning","message":"retrying due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/08vka","resource":"nodev14","stack":"[{/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:67: } {/go/src/github.com/giantswarm/kvm-operator/service/controller/v14/resource/node/create.go:71: } {Get https://api.08vka.k8s.gorgoth.gridscale.kvm.gigantic.io/api/v1/nodes?timeout=30s: net/http: TLS handshake timeout}]","time":"2018-07-13T12:20:04.717123+00:00","underlyingResource":"nodev14"}
```