### PR TITLE
extends error matching for when request got canceled

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -35,7 +35,7 @@ const (
 	//
 	//     https://play.golang.org/p/KuH2V0IXo-J
 	//
-	tlsHandshakeTimeoutPattern = `Get https://api\..*/api/v1/nodes.* net/http: TLS handshake timeout`
+	tlsHandshakeTimeoutPattern = `Get https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled while waiting for connection).*?`
 
 	// transientInvalidCertificatePattern is a regular expression representing the
 	// kind of transient errors related to certificates returned while the guest

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -71,6 +71,11 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.ci-wip-70f9b-5e958.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: dial tcp: lookup api.ci-wip-70f9b-5e958.k8s.godsmack.westeurope.azure.gigantic.io on 10.96.0.10:53: server misbehaving",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 13: request canceled while waiting for connection",
+			errorMessage:  "Get https://api.ci-wip-2317d-c1c86.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Discovered in https://circleci.com/gh/giantswarm/azure-operator/2279.