### PR TITLE
extends error checks with new expression

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -19,7 +19,7 @@ var (
 		regexp.MustCompile(`Get https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled while waiting for connection).*?`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the guest API is not fully up.
-		regexp.MustCompile(`[Get|Post] https://api\..*: x509: certificate is valid for ingress.local, not api\..*`),
+		regexp.MustCompile(`[Get|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
 	}
 )
 

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -76,6 +76,11 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.ci-wip-2317d-c1c86.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 14: certificate signed by unknown authority",
+			errorMessage:  "Get https://api.ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io\")",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
```
Get https://api.ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io\")
```


See https://circleci.com/gh/giantswarm/azure-operator/2291. 