### PR TITLE
extends HTTP verbs for matching

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -11,15 +11,15 @@ var (
 		// A regular expression representing DNS errors for the guest API domain.
 		regexp.MustCompile(`dial tcp: lookup .* on .*:53: (no such host|server misbehaving)`),
 		// A regular expression representing EOF errors for the guest API domain.
-		regexp.MustCompile(`Get https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the guest API domain.
-		regexp.MustCompile(`[Get|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
 		// A regular expression representing TLS errors related to establishing
 		// connections to guest clusters while the guest API is not fully up.
-		regexp.MustCompile(`Get https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the guest API is not fully up.
-		regexp.MustCompile(`[Get|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
 	}
 )
 

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -62,7 +62,7 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			expectedMatch: true,
 		},
 		{
-			description:   "case 11: timeout establishing TLS handshake",
+			description:   "case 11: GET timeout establishing TLS handshake",
 			errorMessage:  "Get https://api.08vka.k8s.gorgoth.gridscale.kvm.gigantic.io/api/v1/nodes?timeout=30s: net/http: TLS handshake timeout",
 			expectedMatch: true,
 		},
@@ -84,6 +84,11 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 		{
 			description:   "case 15: certificate signed by unknown authority",
 			errorMessage:  "Get https://api.ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"ci-cur-42bc2-cba40.k8s.godsmack.westeurope.azure.gigantic.io\")",
+			expectedMatch: true,
+		},
+		{
+			description:   "case 16: Patch timeout establishing TLS handshake",
+			errorMessage:  "Patch https://api.xca65.k8s.geckon.gridscale.kvm.gigantic.io/api/v1/nodes/worker-sruw7-689bd75b49-8gbtl?timeout=30s: net/http: TLS handshake timeout",
 			expectedMatch: true,
 		},
 	}


### PR DESCRIPTION
I run into a wall over and over again because of whatever combination we might use. So I made all URL related matchings more independent of the HTTP verbs. This should catch more and we should have to create less PRs. 