### PR TITLE
extends error matching for TCP connection timeouts

### DIFF
--- a/guest/error.go
+++ b/guest/error.go
@@ -17,6 +17,9 @@ var (
 		// A regular expression representing TLS errors related to establishing
 		// connections to guest clusters while the guest API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
+		// A regular expression representing timeout errors related to establishing
+		// TCP connections to guest clusters while the guest API is not fully up.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the guest API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),

--- a/guest/error_test.go
+++ b/guest/error_test.go
@@ -91,6 +91,11 @@ func Test_IsGuestAPINotAvailable(t *testing.T) {
 			errorMessage:  "Patch https://api.xca65.k8s.geckon.gridscale.kvm.gigantic.io/api/v1/nodes/worker-sruw7-689bd75b49-8gbtl?timeout=30s: net/http: TLS handshake timeout",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 17: Get i/o timeout establishing TCP connection",
+			errorMessage:  "Get https://api.wgrt8.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes?timeout=30s: dial tcp 40.113.146.2:443: i/o timeout",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Discovered during testing on Azure. 