### PR TITLE
Catch error for expired certs

### DIFF
--- a/tenant/error.go
+++ b/tenant/error.go
@@ -22,7 +22,7 @@ var (
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
-		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
 	}
 )
 

--- a/tenant/error_test.go
+++ b/tenant/error_test.go
@@ -101,6 +101,11 @@ func Test_IsAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.cl048.k8s.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/kube-system/configmaps?labelSelector=giantswarm.io%2Fservice-type%3Dmanaged%2C+giantswarm.io%2Fmanaged-by%3Dcluster-operator: EOF",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 19: unable to connect to broken tenant api with expired certs",
+			errorMessage:  "Get https://api.cl048.k8s.gauss.eu-central-1.aws.gigantic.io/api/v1/nodes: x509: certificate has expired or is not yet valid",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change adds support to catch error from expired API certs as one of tenant
APINotAvailable errors. This is used further in `statusresource` which is then
used in provider operators where potential API errors might block further
reconciliation if not correctly handled. For this we need to recognize the
error accordingly.