### PR TITLE
Added new regex for DNS resolution errors

### DIFF
--- a/tenant/error.go
+++ b/tenant/error.go
@@ -10,6 +10,8 @@ var (
 	APINotAvailablePatterns = []*regexp.Regexp{
 		// A regular expression representing DNS errors for the tenant API domain.
 		regexp.MustCompile(`dial tcp: lookup .* on .*:53: (no such host|server misbehaving)`),
+		// Alternative DNS error appearing when running azure-operator with telepresence
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp: lookup .*: no such host`),
 		// A regular expression representing EOF errors for the tenant API domain.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the tenant API domain.

--- a/tenant/error_test.go
+++ b/tenant/error_test.go
@@ -106,6 +106,11 @@ func Test_IsAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.cl048.k8s.gauss.eu-central-1.aws.gigantic.io/api/v1/nodes: x509: certificate has expired or is not yet valid",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 20: dns not ready alternative error (telepresence)",
+			errorMessage:  "Get https://api.72fru.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes: dial tcp: lookup api.72fru.k8s.godsmack.westeurope.azure.gigantic.io: no such host",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
There is no issue regarding this PR.
I was trying to run `azure-operator` locally with telepresence to speedup the development feedback loop.
I was getting an uncaught error like this:

```
Get https://api.72fru.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes: dial tcp: lookup api.72fru.k8s.godsmack.westeurope.azure.gigantic.io: no such host
```

Not sure why the in-cluster running azure operator did get a different DNS resolution error string.