### PR TITLE
Add timeout regex

### DIFF
--- a/tenant/error.go
+++ b/tenant/error.go
@@ -22,6 +22,9 @@ var (
 		// A regular expression representing timeout errors related to establishing
 		// TCP connections to tenant clusters while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
+		// A regular expression representing timeout errors related to awaiting headers
+		// from the tenant API connection.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* .* \(Client.Timeout exceeded while awaiting headers\)`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),

--- a/tenant/error_test.go
+++ b/tenant/error_test.go
@@ -111,6 +111,11 @@ func Test_IsAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.72fru.k8s.godsmack.westeurope.azure.gigantic.io/api/v1/nodes: dial tcp: lookup api.72fru.k8s.godsmack.westeurope.azure.gigantic.io: no such host",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 21: Get i/o timeout from awaiting header",
+			errorMessage:  "Get https://api.pz8mw.k8s.geckon.gridscale.kvm.gigantic.io/api?timeout=10s: context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
For some cases, timeout error is a bit different as below. 
```
E 12/12 20:04:16 /apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/pz8mw failed processing event | operatorkit/controller/controller.go:493 | event=update | version=177314497
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:599:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/basic_resource.go:43:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:64:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/statusresource/create.go:82:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/statusresource/create.go:61:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/statusresource/create.go:257:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/k8sclient/clients.go:117:
	Get https://api.pz8mw.k8s.geckon.gridscale.kvm.gigantic.io/api?timeout=10s: context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```