### PR TITLE
extend error matcher

### DIFF
--- a/tenant/error.go
+++ b/tenant/error.go
@@ -18,7 +18,7 @@ var (
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the tenant API domain.
 		// These may occur when initializing controller runtime clients.
-		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api\?timeout.*: EOF`),
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api\?timeout.*: (EOF|context deadline exceeded)`),
 		// A regular expression representing TLS errors related to establishing
 		// connections to tenant clusters while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),

--- a/tenant/error_test.go
+++ b/tenant/error_test.go
@@ -121,6 +121,11 @@ func Test_IsAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get https://api.jfc8o.k8s.gauss.eu-central-1.aws.gigantic.io/api?timeout=10s: EOF",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 23: context deadline exceeded",
+			errorMessage:  "Get https://api.pnwd0.k8s.eu-central-1.aws.cps.vodafone.com/api?timeout=10s: context deadline exceeded",
+			expectedMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Checking team alerts I noticed `cluster-operator` having issues creating k8s clients. Here `pnwd0` on `viking` has version `10.1.0`. For some reason the TC API is flapping. One thing we can do is to gracefully handle the error, give up on creating the k8s client for that reconciliation loop and try after the next resync period again. No reason to get alerts for the operator throwing errors. 

> {"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:59","event":"update","level":"warning","message":"retrying due to error","object":"/apis/cluster.x-k8s.io/v1alpha2/namespaces/default/machinedeployments/bsog5","resource":"tenantclients","stack":"[{/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/resource/tenantclients/create.go:59: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/k8sclient/clients.go:117: } {Get https://api.pnwd0.k8s.eu-central-1.aws.cps.vodafone.com/api?timeout=10s: context deadline exceeded}]","time":"2020-02-27T18:11:16.504239+00:00","version":"185630171"}