### PR TITLE
Fix error message prefix matching in IsAPINotAvailable()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
+- Fix error message prefix matching in IsAPINotAvailable().
 
 ## [0.2.2] 2020-04-06
 

--- a/tenant/error.go
+++ b/tenant/error.go
@@ -11,26 +11,26 @@ var (
 		// A regular expression representing DNS errors for the tenant API domain.
 		regexp.MustCompile(`dial tcp: lookup .* on .*:53: (no such host|server misbehaving)`),
 		// Alternative DNS error appearing when running azure-operator with telepresence
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..* dial tcp: lookup .*: no such host`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..* dial tcp: lookup .*: no such host`),
 		// A regular expression representing EOF errors for the tenant API domain.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the tenant API domain.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the tenant API domain.
 		// These may occur when initializing controller runtime clients.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..*/api\?timeout.*: (EOF|context deadline exceeded)`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..*/api\?timeout.*: (EOF|context deadline exceeded)`),
 		// A regular expression representing TLS errors related to establishing
 		// connections to tenant clusters while the tenant API is not fully up.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
 		// A regular expression representing timeout errors related to establishing
 		// TCP connections to tenant clusters while the tenant API is not fully up.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..* dial tcp .* i/o timeout`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..* dial tcp .* i/o timeout`),
 		// A regular expression representing timeout errors related to awaiting headers
 		// from the tenant API connection.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..* .* \(Client.Timeout exceeded while awaiting headers\)`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..* .* \(Client.Timeout exceeded while awaiting headers\)`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
-		regexp.MustCompile(`[Get|Patch|Post] "?https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
+		regexp.MustCompile(`Get|Patch|Post "?https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
 	}
 )
 

--- a/tenant/error_test.go
+++ b/tenant/error_test.go
@@ -136,6 +136,16 @@ func Test_IsAPINotAvailable(t *testing.T) {
 			errorMessage:  "Get \"https://api.hixh7.k8s.platypus.eu-west-1.aws.gigantic.io/api?timeout=10s\": EOF",
 			expectedMatch: true,
 		},
+		{
+			description:   "case 26: tenant API unavailable certificate issues - don't match partial prefix",
+			errorMessage:  "t \"https://api.qh99j.k8s.gauss.eu-central-1.aws.gigantic.io/api?timeout=10s\": x509: certificate is valid for ingress.local, not api.qh99j.k8s.gauss.eu-central-1.aws.gigantic.io",
+			expectedMatch: false,
+		},
+		{
+			description:   "case 27: ingress not ready post different domain - don't match partial prefix",
+			errorMessage:  "t https://api.5xchu.aws.gigantic.io: x509: certificate is valid for localhost, not api.5xchu.aws.gigantic.io:",
+			expectedMatch: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Instead of matching any single character from defined group, match whole word
from available options.

See examples here:
https://en.wikipedia.org/wiki/Regular_expression#POSIX_extended

## Checklist

- [x] Update changelog in CHANGELOG.md.
