### PR TITLE
Add failed request error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new error regex for internal API errors often returned when an API is not yet ready to handle requests.
+
 
 
 ## [0.2.3] 2020-04-17

--- a/tenant/error.go
+++ b/tenant/error.go
@@ -31,6 +31,8 @@ var (
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
 		regexp.MustCompile(`Get|Patch|Post "?https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
+		// A regular expression representing arbitrary internal errors from a Kubernetes API server.
+		regexp.MustCompile(`an error on the server \(.*\) has prevented the request from succeeding`),
 	}
 )
 


### PR DESCRIPTION
For https://github.com/giantswarm/kvm-operator/pull/1151

When making a request to a WC Kubernetes API before it has fully initialized, I often get an error like `an error on the server ("") has prevented the request from succeeding` in `kvm-operator`. I believe this classifies as a `APINotAvailableError ` so I am adding to this library. This allows us to wait for the next reconciliation loop in an operator rather than retrying as though it were a temporary failure.

## Checklist

- [x] Update changelog in CHANGELOG.md.
